### PR TITLE
Adds Cloudinary Resource List

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,10 @@
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
+yarn-error.log
 testem.log
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ There is an extra 'matchWidth' option that will resize the video to the width of
 </video>
 ```
 
+### cloudinary-resource-list ###
+
+This component issues an API call to Cloudinary's [Client-side resource lists](http://cloudinary.com/documentation/image_transformations#client_side_resource_lists) and will make all Cloudinary resource items available under an `items` property.
+
+Usage example:
+
+```javascript
+  {{#cloudinary-resource-list 'my-cloudinary-tag' as |resourceList|}}
+    {{#each resourceList.items as |item|}}
+      {{cloudinary-image item.public_id (hash width=100)}}
+    {{/each}}
+  {{/cloudinary-resource-list}}
+```
+
+Optional: the list will be sorted by an `order` metadata property on the Cloudinary resource.
+
+Please see the Cloudinary API docs for all available properties of a resource item.
+
 * `git clone <repository-url>` this repository
 * `cd ember-cli-cloudinary-light`
 * `npm install`
@@ -79,4 +97,3 @@ There is an extra 'matchWidth' option that will resize the video to the width of
 * `ember build`
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
-

--- a/addon/components/cloudinary-resource-list.js
+++ b/addon/components/cloudinary-resource-list.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+import layout from '../templates/components/cloudinary-resource-list';
+import request from 'ember-ajax/request';
+
+const CloudinaryResourceList = Ember.Component.extend({
+  layout,
+
+  init() {
+    this._super(...arguments);
+
+    if (this.get('cloudinaryTag')) {
+      this.fetchCloudinaryResourceList().then(
+        this.handleCloudinaryResponse.bind(this)
+      );
+    }
+  },
+
+  buildUrl() {
+    const cloudName = Ember.getOwner(this).resolveRegistration(
+      'config:environment'
+    ).cloudinary.cloudName;
+    const tag = this.get('cloudinaryTag');
+    return `https://res.cloudinary.com/${cloudName}/image/list/${tag}.json`;
+  },
+
+  fetchCloudinaryResourceList() {
+    let url = this.buildUrl();
+    return request(url).then(response => {
+      return response;
+    });
+  },
+
+  handleCloudinaryResponse(response) {
+    let items = response.resources.sortBy('context.custom.order');
+    this.set('items', items);
+    return items;
+  }
+});
+
+CloudinaryResourceList.reopenClass({
+  positionalParams: ['cloudinaryTag']
+});
+
+export default CloudinaryResourceList;

--- a/addon/templates/components/cloudinary-resource-list.hbs
+++ b/addon/templates/components/cloudinary-resource-list.hbs
@@ -1,0 +1,1 @@
+{{yield (hash items=items)}}

--- a/app/components/cloudinary-resource-list.js
+++ b/app/components/cloudinary-resource-list.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-cloudinary-light/components/cloudinary-resource-list';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,10 @@
 /* eslint-env node */
+'use strict';
+
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/package.json
+++ b/package.json
@@ -23,30 +23,30 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.0.0",
+    "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "2.13.2",
+    "ember-cli": "~2.14.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.13.0",
+    "ember-source": "~2.14.0",
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 4"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,12 @@
 /* eslint-env node */
 module.exports = {
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'PhantomJS'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
+  launch_in_dev: [
+    'PhantomJS',
+    'Chrome'
   ]
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,10 @@
 /* eslint-env node */
+'use strict';
 
 module.exports = function(environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
-    environment: environment,
+    environment,
     rootURL: '/',
     locationType: 'auto',
     EmberENV: {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-
 module.exports = {
   browsers: [
     'ie 9',

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -17,7 +17,7 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/unit/components/cloudinary-resource-list-test.js
+++ b/tests/unit/components/cloudinary-resource-list-test.js
@@ -1,0 +1,47 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const cloudName = 'test-cloud';
+
+moduleFor(
+  'component:cloudinary-resource-list',
+  'Unit | Component | cloudinary-resource-list',
+  {
+    // Specify the other units that are required for this test.
+    // needs: []
+    beforeEach() {
+      this.register('config:environment', {
+        cloudinary: { cloudName }
+      });
+    }
+  }
+);
+
+test('Cloudinary URL is composed correctly', function(assert) {
+  let component = this.subject();
+
+  let tag = 'my-tag';
+  component.set('cloudinaryTag', tag);
+
+  let url = component.buildUrl();
+  assert.equal(
+    url,
+    `https://res.cloudinary.com/${cloudName}/image/list/${tag}.json`,
+    'Url is OK'
+  );
+});
+
+test('Response is sorted correctly', function(assert) {
+  let component = this.subject();
+
+  let response = {
+    resources: Ember.A([
+      { publid_id: 1, context: { custom: { order: 3 } } },
+      { publid_id: 2, context: { custom: { order: 2 } } },
+      { publid_id: 3, context: { custom: { order: 1 } } }
+    ])
+  };
+
+  let orderedItems = component.handleCloudinaryResponse(response);
+  assert.equal(orderedItems[0].publid_id, 3, 'Resource items order is OK');
+});


### PR DESCRIPTION
I had a need to support [Cloudinary's Client Side Resource Lists](http://cloudinary.com/documentation/image_transformations#client_side_resource_lists) and added the feature to this addon.

Cloudinary's Client Side Resource Lists allow you to list cloudinary resources for a given tag.

Changes:
* adds a `cloudinary-resource-list` component that makes an API call to Cloudinary and exposes an `items` property containing an Array of cloudinary resources, which can be used via the contextual components pattern in templates
* added unit tests to cover the main functionality
* updated the README
* upgraded the addon to Ember 2.14 (the previous version was incompatible with my Node 8 development environment)

@davidbilling please let me know what you think or if it requires any changes.

