### PR TITLE
Fixes an issue with parsing fetch response from Cloudinary resource lists

### DIFF
--- a/addon/components/cloudinary-resource-list.js
+++ b/addon/components/cloudinary-resource-list.js
@@ -4,6 +4,7 @@ import layout from '../templates/components/cloudinary-resource-list';
 import { get } from '@ember/object';
 import { set } from '@ember/object';
 import fetch from 'fetch';
+import { debug } from '@ember/debug';
 
 const CloudinaryResourceList = Component.extend({
   layout,
@@ -14,7 +15,9 @@ const CloudinaryResourceList = Component.extend({
     if (get(this, 'cloudinaryTag')) {
       this.fetchCloudinaryResourceList().then(
         this.handleCloudinaryResponse.bind(this)
-      );
+      ).catch(error => {
+        debug(`Error fetching Cloudinary Resource List: ${error}`);
+      })
     }
   },
 
@@ -28,9 +31,9 @@ const CloudinaryResourceList = Component.extend({
 
   fetchCloudinaryResourceList() {
     let url = this.buildUrl();
-    fetch(url).then(function(response) {
-      return response;
-    });    
+    return fetch(url).then(function(response) {
+      return response.json();
+    });
   },
 
   handleCloudinaryResponse(response) {

--- a/tests/integration/components/cloudinary-resource-list-test.js
+++ b/tests/integration/components/cloudinary-resource-list-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | cloudinary-resource-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it gracefully handles ajax errors', async function(assert) {
+    await render(hbs`
+      {{#cloudinary-resource-list 'test'}}
+        template block text
+      {{/cloudinary-resource-list}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
* Fixes an issue with parsing the fetch response from Cloudinary resource lists
* Adds `catch` to gracefully handle any future fetch errors
* Adds a basic component test