### PR TITLE
Improves test coverage for cloudinary resource list component

### DIFF
--- a/addon/components/cloudinary-resource-list.js
+++ b/addon/components/cloudinary-resource-list.js
@@ -37,9 +37,25 @@ const CloudinaryResourceList = Component.extend({
   },
 
   handleCloudinaryResponse(response) {
-    let items = response.resources.sortBy('context.custom.order');
-    set(this, 'items', items);
-    return items;
+    response.resources.sort((a, b) => {
+      if (!a.context || !a.context.custom || !b.context || !b.context.custom) {
+        return;
+      }
+
+      let { context: { custom: { order: orderA }}} = a;
+      let { context: { custom: { order: orderB }}} = b;
+
+      if (orderA < orderB) {
+        return -1;
+      }
+      if (orderA > orderB) {
+        return 1;
+      }
+      return 0;
+    })
+
+    set(this, 'items', response.resources);
+    return response;
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
+    "ember-cli-pretender": "^3.0.0",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",


### PR DESCRIPTION
* Adds more component tests to cover a few use cases for the `cloudinary-resource-list` component.
* Adds Pretender to mock Cloudinary api and payloads